### PR TITLE
Added Get method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,19 @@ Stores a key-value pair in the Lunar service.
 lunar.set('exampleKey', 'exampleValue', 60);
 ```
 
+#### `get(key)`
+
+Retrieves the value associated with a given key from the Lunar service.
+
+- **key** (string): The key for which the value needs to be retrieved.
+
+Returns the value associated with the key, or `null` if the key does not exist or has expired.
+
+```javascript
+const value = lunar.get('exampleKey');
+console.log(value); // Outputs the value or null if the key doesn't exist.
+```
+
 ## Error Handling
 
 The `set` method will catch any errors that occur during the execution of the command and return the error message. If the operation is successful, it returns the standard output from the command.

--- a/src/index.js
+++ b/src/index.js
@@ -22,5 +22,21 @@ class Lunar {
             return error
         }
     }
+    get(key){
+        try {
+            const command = `
+                lunar
+                get ${key}
+            `
+            exec(command, (error, stdout, stderr) => {
+                if (error) {
+                    return `exec error: ${error}`;
+                }
+                return stdout
+            });
+        } catch (error) {
+            return error
+        }
+    }
 }
 module.exports = Lunar;


### PR DESCRIPTION
This PR introduces the `get` method to the Lunar service, allowing users to retrieve values stored by a key. The method complements the existing `set` functionality, enabling a full key-value store interaction.

### **Key Changes**
- **New `get(key)` method**: Retrieves the value associated with the provided key. If the key does not exist or has expired (if a TTL was set during `set`), the method will return `null`.
- Updated the documentation to include usage examples for the `get` method.

### **Usage Example**
```javascript
lunar.set('exampleKey', 'exampleValue', 60);
const value = lunar.get('exampleKey'); 
console.log(value); // Outputs: 'exampleValue'
```

### **Why this change?**
This method improves the utility of the Lunar service by providing a way to retrieve stored data, making it more versatile for various use cases, such as session management or temporary data caching.